### PR TITLE
xrtx: Don't hardcode UART major

### DIFF
--- a/xtrx.c
+++ b/xtrx.c
@@ -524,16 +524,10 @@ static struct uart_ops xtrx_uart_ops = {
 	//.ioctl          = xtrx_uart_verify_ioctl,
 };
 
-
-// TODO get rid of constant
-#define TTY_XTRX_MAJOR 234
-
 static struct uart_driver xtrx_uart_driver = {
 	.owner		= THIS_MODULE,
 	.driver_name	= "xtrxuart",
 	.dev_name	= "ttyXTRX",
-	.major		= TTY_XTRX_MAJOR,
-	.minor		= 64,
 	.nr		= XTRX_UART_NUM * MAX_XTRX_DEVS,
 	.cons		= NULL,
 };


### PR DESCRIPTION
Currently thedriver hardcodes the UART major as 234. However, this is
VERY BAD (TM) as 234 is reserved for dynamic allocation BY THE KERNEL.
Trying to use 234 in this way in the driver will cause conflicts with
other dynamically major-allocated drivers in the kernel. Fortunately,
simply leaving out the `.major/.minor` field will cause the kernel
to dynamically allocate a proper major/minor number for the UART device.

Fixes: https://github.com/xtrx-sdr/images/issues/102
Signed-off-by: Keno Fischer <keno@juliacomputing.com>

@sergforce is there userspace that depends on this hardcoding? If so, we might want to fix that as well.