### PR TITLE
xtrx: Fix double free

### DIFF
--- a/xtrx.c
+++ b/xtrx.c
@@ -1509,7 +1509,6 @@ static int __init xtrx_init(void)
 	return 0;
 
 failed_pci:
-	class_unregister(xtrx_class);
 	class_destroy(xtrx_class);
 failed_setup_cdev:
 	unregister_chrdev_region(dev_first, devices);
@@ -1526,7 +1525,6 @@ static void __exit xtrx_cleanup(void)
 
 	pci_unregister_driver(&xtrx_driver);
 
-	class_unregister(xtrx_class);
 	class_destroy(xtrx_class);
 
 	unregister_chrdev_region(dev_first, devices);


### PR DESCRIPTION
The two functions `class_unregister` and `class_release` are essentially
aliases. This fixes the following issue which causes use-after-free vulnerability
on module unload:

```
[ 3672.546444] ------------[ cut here ]------------
[ 3672.546444] refcount_t: underflow; use-after-free.
[ 3672.546450] WARNING: CPU: 3 PID: 31132 at lib/refcount.c:28 refcount_warn_saturate+0xae/0xf0
[ 3672.546454] Modules linked in: xtrx(OE-) wireguard curve25519_x86_64 libchacha20poly1305 chacha_x86_64 poly1305_x86_64 libblake2s blake2s_x86_64 ip6_udp_tunnel udp_tunnel libcurve25519_generic libchacha libblake2s_generic nls_iso8859_1 dm_multipath scsi_dh_rdac scsi_dh_emc scsi_dh_alua snd_hda_codec_hdmi snd_sof_pci snd_sof_intel_hda_common snd_soc_hdac_hda snd_sof_intel_hda snd_sof_intel_byt snd_hda_codec_realtek snd_sof_intel_ipc snd_hda_codec_generic intel_rapl_msr mei_hdcp snd_sof snd_sof_xtensa_dsp snd_hda_ext_core snd_soc_acpi_intel_match snd_soc_acpi ledtrig_audio snd_hda_intel snd_intel_dspcfg intel_rapl_common soundwire_intel x86_pkg_temp_thermal soundwire_generic_allocation intel_powerclamp soundwire_cadence coretemp snd_hda_codec snd_hda_core kvm_intel snd_hwdep soundwire_bus snd_soc_core snd_compress kvm ac97_bus snd_pcm_dmaengine snd_pcm snd_timer rapl snd mei_me intel_cstate efi_pstore joydev wmi_bmof soundcore 8250_dw ee1004 input_leds mei intel_pch_thermal mac_hid
[ 3672.546485]  acpi_pad acpi_tad sch_fq_codel msr ip_tables x_tables autofs4 btrfs blake2b_generic hid_logitech_hidpp hid_logitech_dj hid_generic usbhid hid dm_crypt raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor raid6_pq libcrc32c raid1 raid0 multipath linear i915 i2c_algo_bit drm_kms_helper crct10dif_pclmul syscopyarea crc32_pclmul ghash_clmulni_intel sysfillrect sysimgblt fb_sys_fops aesni_intel crypto_simd cec cryptd rc_core glue_helper thunderbolt drm nvme e1000e i2c_i801 nvme_core i2c_smbus intel_lpss_pci intel_lpss ahci idma64 xhci_pci libahci virt_dma xhci_pci_renesas wmi video
[ 3672.546509] CPU: 3 PID: 31132 Comm: rmmod Tainted: G           OE     5.11.0-22-generic #23-Ubuntu
[ 3672.546510] Hardware name: Supermicro C9Z390-CG/C9Z390-CG, BIOS 1.2 11/18/2019
[ 3672.546511] RIP: 0010:refcount_warn_saturate+0xae/0xf0
[ 3672.546514] Code: b7 32 96 01 01 e8 5f f7 62 00 0f 0b 5d c3 80 3d a4 32 96 01 00 75 91 48 c7 c7 40 c6 a0 8d c6 05 94 32 96 01 01 e8 3f f7 62 00 <0f> 0b 5d c3 80 3d 82 32 96 01 00 0f 85 6d ff ff ff 48 c7 c7 98 c6
[ 3672.546515] RSP: 0018:ffffa3abc423fe38 EFLAGS: 00010282
[ 3672.546516] RAX: 0000000000000000 RBX: ffff8c8ac43b7d80 RCX: ffff8c99ee4d8ac8
[ 3672.546517] RDX: 00000000ffffffd8 RSI: 0000000000000027 RDI: ffff8c99ee4d8ac0
[ 3672.546518] RBP: ffffa3abc423fe38 R08: 0000000000000000 R09: ffffa3abc423fc18
[ 3672.546518] R10: ffffa3abc423fc10 R11: ffffffff8e153568 R12: ffff8c8ac317c018
[ 3672.546519] R13: 0000000000000000 R14: 0000000000000000 R15: 0000000000000000
[ 3672.546520] FS:  00007fd544a79580(0000) GS:ffff8c99ee4c0000(0000) knlGS:0000000000000000
[ 3672.546521] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 3672.546522] CR2: 00005602dd13a388 CR3: 00000001d3ab6001 CR4: 00000000003706e0
[ 3672.546522] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
[ 3672.546523] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
[ 3672.546524] Call Trace:
[ 3672.546526]  kobject_put+0x63/0x70
[ 3672.546528]  kset_unregister+0x32/0x40
[ 3672.546529]  class_unregister+0x2c/0x50
[ 3672.546531]  class_destroy+0x1c/0x20
[ 3672.546533]  xtrx_cleanup+0x32/0xcb3 [xtrx]
[ 3672.546535]  __do_sys_delete_module.constprop.0+0x144/0x260
[ 3672.546537]  ? exit_to_user_mode_loop+0xec/0x160
[ 3672.546539]  __x64_sys_delete_module+0x12/0x20
[ 3672.546540]  do_syscall_64+0x38/0x90
[ 3672.546542]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[ 3672.546544] RIP: 0033:0x7fd544bbba0b
[ 3672.546545] Code: 73 01 c3 48 8b 0d 5d 74 0c 00 f7 d8 64 89 01 48 83 c8 ff c3 66 2e 0f 1f 84 00 00 00 00 00 90 f3 0f 1e fa b8 b0 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d 2d 74 0c 00 f7 d8 64 89 01 48
[ 3672.546546] RSP: 002b:00007ffff62e3f08 EFLAGS: 00000206 ORIG_RAX: 00000000000000b0
[ 3672.546547] RAX: ffffffffffffffda RBX: 00005602dd12f760 RCX: 00007fd544bbba0b
[ 3672.546548] RDX: 000000000000000a RSI: 0000000000000800 RDI: 00005602dd12f7c8
[ 3672.546549] RBP: 0000000000000000 R08: 0000000000000000 R09: 0000000000000000
[ 3672.546549] R10: 00007fd544c35ac0 R11: 0000000000000206 R12: 00007ffff62e4130
[ 3672.546550] R13: 00007ffff62e58c4 R14: 00005602dd12f2a0 R15: 00005602dd12f760
[ 3672.546551] ---[ end trace 552e3dfe77a15fdb ]---
```

Signed-off-by: Keno Fischer <keno@juliacomputing.com>