### PR TITLE
xtrx.c: fix build error with kernel 6.1

### DIFF
--- a/xtrx.c
+++ b/xtrx.c
@@ -361,8 +361,13 @@ static void xtrx_uart_shutdown(struct uart_port *port)
 }
 
 static void xtrx_uart_set_termios(struct uart_port *port,
-				 struct ktermios *new,
-				 struct ktermios *old)
+				  struct ktermios *new,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+				  struct ktermios *old
+#else
+				  const struct ktermios *old
+#endif
+	)
 {
 	unsigned long flags;
 


### PR DESCRIPTION
uart_ops.set_termios type changes a little in kernel 6.1. Thus we need to change xtrx_uart_set_termios() third parameter as a const pointer when building with kernel version >= 6.1

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>