### PR TITLE
xtrx.c: fix build error with kernel 6.3

### DIFF
--- a/xtrx.c
+++ b/xtrx.c
@@ -1072,7 +1072,11 @@ static int xtrxfd_mmap(struct file *filp, struct vm_area_struct *vma)
 			return -EINVAL;
 		}
 		//vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 		vma->vm_flags |= VM_LOCKED;
+#else
+		vm_flags_set(vma, VM_LOCKED);
+#endif
 
 		if (remap_pfn_range(vma, vma->vm_start,
 							virt_to_phys((void*)((unsigned long)xtrxdev->shared_mmap)) >> PAGE_SHIFT,
@@ -1087,7 +1091,11 @@ static int xtrxfd_mmap(struct file *filp, struct vm_area_struct *vma)
 		unsigned long pfn;
 		int bar = (region == REGION_CTRL) ? 0 : 1;
 		vma->vm_page_prot = pgprot_device(vma->vm_page_prot);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 		vma->vm_flags |= VM_IO;
+#else
+		vm_flags_set(vma, VM_IO);
+#endif
 		pfn = pci_resource_start(xtrxdev->pdev, bar) >> PAGE_SHIFT;
 
 		if (io_remap_pfn_range(vma, vma->vm_start, pfn,
@@ -1112,7 +1120,11 @@ static int xtrxfd_mmap(struct file *filp, struct vm_area_struct *vma)
 		}
 
 		//vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 		vma->vm_flags |= VM_LOCKED;
+#else
+		vm_flags_set(vma, VM_LOCKED);
+#endif
 
 		for (i = 0, off = 0; i < BUFS; ++i, off += bufsize) {
 #ifdef VA_DMA_ADDR_FIXUP

--- a/xtrx.c
+++ b/xtrx.c
@@ -361,8 +361,13 @@ static void xtrx_uart_shutdown(struct uart_port *port)
 }
 
 static void xtrx_uart_set_termios(struct uart_port *port,
-				 struct ktermios *new,
-				 struct ktermios *old)
+				  struct ktermios *new,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+				  struct ktermios *old
+#else
+				  const struct ktermios *old
+#endif
+	)
 {
 	unsigned long flags;
 


### PR DESCRIPTION
This is based on previous merge request because we also need to fix build fail on kernel 6.1.
Please review this branch when it is possible. Thanks.
