### PR TITLE
update ARM conditional compilation flag + replace dma_alloc_coherent with dmam_alloc_coherent

### DIFF
--- a/xtrx.c
+++ b/xtrx.c
@@ -624,7 +624,7 @@ static int xtrx_allocdma(struct xtrx_dev *d, struct xtrx_dmabuf_nfo *pbufs, unsi
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
 		pbufs[i].virt = pci_alloc_consistent(d->pdev, buflen, &pbufs[i].phys);
 #else
-		pbufs[i].virt = dma_alloc_coherent(&d->pdev->dev, buflen, &pbufs[i].phys, GFP_KERNEL);
+		pbufs[i].virt = dmam_alloc_coherent(&d->pdev->dev, buflen, &pbufs[i].phys, GFP_KERNEL);
 #endif
 		if (!pbufs[i].virt) {
 			printk(KERN_INFO PFX "Failed to allocate %d DMA buffer", i);

--- a/xtrx.c
+++ b/xtrx.c
@@ -177,7 +177,8 @@ MODULE_VERSION("0.1");
  * mmaped to userspce. Convertion DMA->PA->VA does the trick on that
  * platforms
  */
-#ifdef CONFIG_CPU_RK3399
+
+#if defined(__arm__) || defined(__aarch64__)
 #define VA_DMA_ADDR_FIXUP
 #endif
 


### PR DESCRIPTION
The driver modified according to this pull request was tested as functional on a Raspberry Pi5 running Linux kernel 6.6
as described at https://github.com/oscimp/xtrx_on_rpi5 and on an x86-based PC running kernel 6.9. Compilation will fail on a kernel 6.10 and later due to the loss of uart_circ_empty().